### PR TITLE
Experiment with "lookahead" functionality

### DIFF
--- a/src/drive/controller.cc
+++ b/src/drive/controller.cc
@@ -152,6 +152,7 @@ bool DriveController::GetControl(const DriverConfig &config,
   float k = -steering_in * 2 * fabs(steering_in);
   float vk = k;  // curvature to use for velocity calc
   float vmax = throttle_in * config.speed_limit * 0.01;
+  float target_v = vmax;
   if (autodrive) {
     k = autok;
     // vk = fmax(fabs(vk_), fabs(k));
@@ -159,7 +160,7 @@ bool DriveController::GetControl(const DriverConfig &config,
    
     float v2 = sqrt(config.traction_limit*0.01 / fabs(vk_) ) ;
     float dV = vr_ -  v2 ; //if current velocity is high and v2 is low, the term dV will be positive. if it is negative, the if condition will not be met anyway
-    float decel_req = (dv/dist)*vr_ ; //dv/dx * dx/dt = dv/dt = deceleration required to hit that speed.
+    float decel_req = (dV/dist)*vr_ ; //dv/dx * dx/dt = dv/dt = deceleration required to hit that speed.
     if(decel_req > 0.5*config.traction_limit) // why 0.5? Idk. Seemed like a good idea to leave at least 1/2 the traction for turning.
     {
       target_v = v2; //set target velocity as v2 if the deceleration required to achieve it is more than 1/2 the traction limit

--- a/src/drive/controller.h
+++ b/src/drive/controller.h
@@ -52,6 +52,8 @@ class DriveController {
 
   float cx_, cy_, nx_, ny_;
 
+  float dist; //distance to the maximum curvature point.
+
  private:
   TrajectoryTracker track_;
 };

--- a/src/drive/trajtrack.cc
+++ b/src/drive/trajtrack.cc
@@ -61,20 +61,30 @@ bool TrajectoryTracker::GetTarget(float x, float y, int lookahead,
   int mini = 0;
   float mind = 1e12;
 
-  for (int i = 0; i < n_pts_; i++) {
+  for (int i = 0; i < n_pts_; i++) 
+  {
     const TrajectoryPoint &p = pts_[i];
     float dist = (p.x - x)*(p.x - x) + (p.y - y)*(p.y - y);
-    if (dist < mind) {
+    if (dist < mind) 
+    {
       mind = dist;
       mini = i;
     }
   }
 
+/*
+
+*/
+
 //So the idea is, we find the first local maxima of the curvature of the track ahead of us. The reason why 
 //we want the first local maxima is because the points under consideration might include 2 points where the kappa is high (like in a chicane). 
 //We only concern ourselves with the first instance of max kappa.
-  float del_k, last_del_k, braking_dist;
-  float max_k;
+  float del_k, last_del_k, braking_dist[2], pos_x[2], pos_y[2];
+  float max_k[2]; //upto 2 local maximas. Why 2? because it is highly unlikely that an optimized trajectory would contain 3 local maximas in succession
+                  //so close to each other and so drastically different that premature braking would be required for the 3rd local maxima. Thats just bad optimisation IMO
+  uint8_t count = 0; //sentinel variable
+  float out_k, out_d; //these will be the final outputs.
+
   for (int i = mini; i < mini + n_pts_ ; i++) //circle around from the current target position.
   {
     int a = i%n_pts_ ; // prevent memory issues.
@@ -89,13 +99,35 @@ bool TrajectoryTracker::GetTarget(float x, float y, int lookahead,
     {
       if(del_k*last_del_k < 0) // the sign of the derivative of the curvature changes around the sharp turns. therefore if the product of successive derivatives is negative, it indicates a sharp turn
       {
-        max_k = p2.k; //store value of max_k,distance and break the loop.
-        braking_dist = sqrt((p2.x - x)*(p2.x - x) + (p2.y - y)*(p2.y - y)); //get value of approximate distance to that point 
-        //I say approximate because it is the straight line distance and not the distance along the trajectory (while that would be ideal, it would take a while to figure out) 
+        max_k[count] = p2.k; //store value of max_k,distance and break the loop.
+        braking_dist[count] = sqrt((p2.x - x)*(p2.x - x) + (p2.y - y)*(p2.y - y)); //get value of approximate distance to that point 
+        //I say approximate because it is the straight line distance and not the distance along the trajectory (while that would be ideal, it would take a while (for me) to figure out) 
+        pos_x[count] = p2.x;
+        pos_y[count] = p2.y; //store coordinates
+        count++;
+      }
+      if(count>=2) //2 points found
+      {
         break;
       }
     }
   }
+
+  out_k = max_k[0];
+  out_d = braking_dist[0];
+
+  float gap_inverse = 1/sqrt( (pos_x[1] - pos_x[0])*(pos_x[1] - pos_x[0]) + (pos_y[1] - pos_y[0])*(pos_y[1] - pos_y[0]) ); //distance between the 2 points where local maximas occur.
+  float k_dash_inverse = 1/sqrt( fabs(max_k[0]*max_k[1]) );
+  float k1_inverse = 1/fabs(max_k[0]);
+  float condition = gap_inverse*(k1_inverse - k_dash_inverse) ;
+  if(condition > 1) //this condition was determined mathematically. Images for proof will be in pull request.
+  {
+    out_k = max_k[1];
+    out_d = braking_dist[1];
+  }
+  //intuitive explanation : the farther away the points are, the less important the second maxima (gap inverse). if the second local maxima has a curvature larger than the first,
+  // the quantity "condition" becomes larger as k_dash_inverse is inversely proportional to second maxima's magnitude and therefore resulting in a larger net result.
+  // if the first local maxima has the same curvature as the second, the value of condition becomes 0 and negative if the curvature of the first maxima is greater than that of the second maxima.
 
   // int li = (mini + lookahead) % n_pts_; //didn't seem like this line was doing anything useful so I commented it.
 
@@ -105,8 +137,8 @@ bool TrajectoryTracker::GetTarget(float x, float y, int lookahead,
   *normx = p.nx;
   *normy = p.ny;
   *kappa = p.k;
-  *lookahead_kappa = max_k;
-  *dist = braking_dist; //will need this later 
+  *lookahead_kappa = out_k;
+  *dist = out_d; //will need this later 
   // printf("i %d pt %f %f norm %f %f k %f\n", mini, p.x, p.y, p.nx, p.ny, p.k);
 
   return true;

--- a/src/drive/trajtrack.cc
+++ b/src/drive/trajtrack.cc
@@ -82,7 +82,7 @@ bool TrajectoryTracker::GetTarget(float x, float y, int lookahead,
   float del_k, last_del_k, braking_dist[2], pos_x[2], pos_y[2];
   float max_k[2]; //upto 2 local maximas. Why 2? because it is highly unlikely that an optimized trajectory would contain 3 local maximas in succession
                   //so close to each other and so drastically different that premature braking would be required for the 3rd local maxima. Thats just bad optimisation IMO
-  uint8_t count = 0; //sentinel variable
+  int count = 0; //sentinel variable
   float out_k, out_d; //these will be the final outputs.
 
   for (int i = mini; i < mini + n_pts_ ; i++) //circle around from the current target position.

--- a/src/drive/trajtrack.cc
+++ b/src/drive/trajtrack.cc
@@ -61,12 +61,10 @@ bool TrajectoryTracker::GetTarget(float x, float y, int lookahead,
   int mini = 0;
   float mind = 1e12;
 
-  for (int i = 0; i < n_pts_; i++) 
-  {
+  for (int i = 0; i < n_pts_; i++) {
     const TrajectoryPoint &p = pts_[i];
     float dist = (p.x - x)*(p.x - x) + (p.y - y)*(p.y - y);
-    if (dist < mind) 
-    {
+    if (dist < mind) {
       mind = dist;
       mini = i;
     }

--- a/src/drive/trajtrack.h
+++ b/src/drive/trajtrack.h
@@ -17,7 +17,7 @@ class TrajectoryTracker {
   bool GetTarget(float x, float y, int lookahead,
       float *closestx, float *closesty,
       float *normx, float *normy,
-      float *kappa, float *lookahead_kappa);
+      float *kappa, float *lookahead_kappa, float *dist);
 
  private:
   int n_pts_;

--- a/src/drive/trajtrack_test.cc
+++ b/src/drive/trajtrack_test.cc
@@ -11,10 +11,10 @@ int main() {
     return 1;
   }
 
-  float cx, cy, nx, ny, k, t;
+  float cx, cy, nx, ny, k, t,d;
   if (!tt.GetTarget(/*x=*/ 0, /*y=*/0, /*lookahead=*/12, /*closestx=*/&cx,
           /*closesty=*/&cy, /*normx=*/&nx, /*normy=*/&ny, /*kappa=*/&k,
-          /*lookahead_kappa=*/&t)) {
+          /*lookahead_kappa=*/&t, /*breaking distance */&d)) {
     fprintf(stderr, "failed to get target?!");
     return 1;
   }
@@ -23,7 +23,7 @@ int main() {
 
   if (!tt.GetTarget(/*x=*/ 51, /*y=*/20, /*lookahead=*/42, /*closestx=*/&cx,
             /*closesty=*/&cy, /*normx=*/&nx, /*normy=*/&ny, /*kappa=*/&k,
-            /*lookahead_kappa=*/&t)) {
+            /*lookahead_kappa=*/&t,/*breaking distance*/ &d)) {
     fprintf(stderr, "failed to get target?!");
     return 1;
   }

--- a/src/drive/trajtrack_test.cc
+++ b/src/drive/trajtrack_test.cc
@@ -14,7 +14,7 @@ int main() {
   float cx, cy, nx, ny, k, t,d;
   if (!tt.GetTarget(/*x=*/ 0, /*y=*/0, /*lookahead=*/12, /*closestx=*/&cx,
           /*closesty=*/&cy, /*normx=*/&nx, /*normy=*/&ny, /*kappa=*/&k,
-          /*lookahead_kappa=*/&t, /*breaking distance */&d)) {
+          /*lookahead_kappa=*/&t, /*breaking distance=*/&d)) {
     fprintf(stderr, "failed to get target?!");
     return 1;
   }
@@ -23,7 +23,7 @@ int main() {
 
   if (!tt.GetTarget(/*x=*/ 51, /*y=*/20, /*lookahead=*/42, /*closestx=*/&cx,
             /*closesty=*/&cy, /*normx=*/&nx, /*normy=*/&ny, /*kappa=*/&k,
-            /*lookahead_kappa=*/&t,/*breaking distance*/ &d)) {
+            /*lookahead_kappa=*/&t,/*breaking distance=*/ &d)) {
     fprintf(stderr, "failed to get target?!");
     return 1;
   }


### PR DESCRIPTION
Basic outline :
in trajtrack.cc, in function GetTarget : 
1) Find the nearest point where the curvature is maximum ( a local "maxima" for curvature, although it is indifferent to the direction of turning. The local maxima is found by evaluating the product of derivatives of curvature around a point. if the product of current derivative and previous derivative is negative, the sharpest point was just encountered. The product is positive as long as the curvature's magnitude keeps increasing)
2) Find the distance to that point (for now using euclidean distance. Can be improved later). 

in controller.cc, in function GetControl, in the if condition for autodrive : 
3) Evaluate whether braking is required by evaluating the deceleration required to hit the maximum speed at the point of maximum kappa found in 1). the deceleration is computed as dv/dx*current velocity (dv/dx * dx/dt = dv/dt . This works as long as we assume the deceleration to be uniform. again, these assumptions can be improved, but the basic idea would remain). 
If the deceleration required is more than half the traction limit (because some traction will be required for turning too. Again, an assumption), then set the target velocity as the velocity at that point (max kappa point) and if not then set the target velocity as the velocity for the current kappa or the config.speed limit (whichever is smaller). 