### PR TITLE
IMU: Enable easy switching between different IMU types in CMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,10 @@ $ make -j4
 The main executable will be in `build/drive/drive`; scp that to your raspberry
 pi on the car, pair a bluetooth joystick, and run it.
 
+### Configurations
+If you are running version 1.2 or below of the Cycloid HAT board, you have a
+different IMU (MPU-9250/MPU-9150). You need to enable this in CMake. The option
+is called `MPU9250` and can be turned to `ON` by passing `-D MPU9250=ON` in a
+cmake call (like the inital configuration), or you can run enable it directly
+in `ccmake` or `cmake-gui`.
+

--- a/src/hw/imu/CMakeLists.txt
+++ b/src/hw/imu/CMakeLists.txt
@@ -1,13 +1,27 @@
 # newer board revisions use ICM20600 instead of MPU-9250
-# FIXME(asloane): make this configurable somehow without modifying makefiles
+option(
+  MPU9250
+  "Use the MPU-9250 IMU instead of the ICM20600. The MPU-9250 is only used on Cycloid HAT boards =< 1.2"
+  OFF)
+# The MPU-9150 and MPU-9250 are virtually identical in this context!
 
-add_library(imu icm20600.cc)
+# Implementation notes: The below is purposefully more verbose than necessary.
+# However, by definining `imu` to be only an INTERFACE library, we guarantee
+# that all targets get compiled by default.
+add_library(mpu9150 mpu9150.cc)
+add_library(icm20600 icm20600.cc)
+add_library(imu INTERFACE)
+if(${MPU9250})
+  target_link_libraries(imu INTERFACE mpu9150)
+else()
+  target_link_libraries(imu INTERFACE icm20600)
+endif()
 
-add_executable(icm20600 icm20600_main.cc)
-target_link_libraries(icm20600 imu gpio)
+add_executable(icm20600_main icm20600_main.cc)
+target_link_libraries(icm20600_main icm20600 gpio)
 
-add_executable(mpu9150 mpu9150_main.cc mpu9150.cc)
-target_link_libraries(mpu9150 gpio)
+add_executable(mpu9150_main mpu9150_main.cc)
+target_link_libraries(mpu9150_main mpu9150 gpio)
 
 install(TARGETS icm20600 DESTINATION bin)
 install(TARGETS mpu9150 DESTINATION bin)


### PR DESCRIPTION
This enables switching the IMU type by passing `cmake -D MPU9250=ON .`.  